### PR TITLE
added the missing '@liqvid/recording' module

### DIFF
--- a/demos/gsap/cursor/package.json
+++ b/demos/gsap/cursor/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@liqvid/recording": "^0.1.0",
     "@lqv/cursor": "^0.1.0",
     "@lqv/gsap": "^0.0.1",
     "@lqv/playback": "^0.0.1",


### PR DESCRIPTION
was showing before "Cannot find module '@liqvid/recording' or its corresponding type declarations."